### PR TITLE
Add CeloscanProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,21 @@ const txResponse = await signer.sendTransaction({
 })
 ```
 
+## Getting transaction history with CeloscanProvider
+
+You can also rely on EthersProviders functionality, such as getting an account's transaction history, using our alternative CeloscanProvider
+
+```js
+import { CeloscanProvider } from '@celo-tools/celo-ethers-wrapper'
+
+// You can use 'celo', 'alfajores' or 'baklava'.
+// Default is 'celo' (mainnet)
+const scanProvider = new CeloscanProvider('alfajores');
+
+const history = await provider.getHistory(YOUR_ACCOUNT);
+console.info("History:", history);
+```
+
 ## Examples
 
 See the tests under `/test` for more detailed examples.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "build:main": "tsc -p tsconfig.json",
     "build:module": "tsc -p tsconfig.module.json",
     "test:contract": "ts-node test/useContract.ts",
-    "test:deploy": "ts-node test/deployContract.ts"
+    "test:deploy": "ts-node test/deployContract.ts",
+    "test:history": "ts-node test/getHistory.ts"
   },
   "engines": {
     "node": ">=10"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./lib/CeloProvider";
 export * from "./lib/CeloWallet";
 export * from "./lib/StaticCeloProvider";
+export * from "./lib/CeloscanProvider";
 export * from "./lib/transactions";

--- a/src/lib/CeloscanProvider.ts
+++ b/src/lib/CeloscanProvider.ts
@@ -1,0 +1,36 @@
+import { logger, providers, utils } from "ethers";
+import { getNetwork } from "./networks";
+
+export class CeloscanProvider extends providers.EtherscanProvider {
+    constructor(
+        networkish: providers.Networkish = 'celo',
+        apiKey?: string
+    ) {
+        const network = getNetwork(networkish);
+        if (network == null) {
+            return logger.throwError(
+                `unknown network: ${JSON.stringify(network)}`,
+                utils.Logger.errors.UNSUPPORTED_OPERATION,
+                {
+                    operation: 'getNetwork',
+                    value: networkish,
+                },
+            );
+        }
+        super(network, apiKey);
+    }
+
+    getBaseUrl(): string {
+        switch (this.network ? this.network.name : "invalid") {
+            case "celo":
+                return "https:/\/explorer.celo.org/mainnet";
+            case "alfajores":
+                return "https:/\/explorer.celo.org/alfajores";
+            case "baklava":
+                return "https:/\/explorer.celo.org/baklava";
+            default:
+        };
+
+        return logger.throwArgumentError("unsupported network", "network", this.network.name);
+    }
+}

--- a/src/lib/CeloscanProvider.ts
+++ b/src/lib/CeloscanProvider.ts
@@ -23,11 +23,12 @@ export class CeloscanProvider extends providers.EtherscanProvider {
     getBaseUrl(): string {
         switch (this.network ? this.network.name : "invalid") {
             case "celo":
-                return "https:/\/explorer.celo.org/mainnet";
+                return "https://api.celoscan.io";
             case "alfajores":
-                return "https:/\/explorer.celo.org/alfajores";
+                return "https://alfajores.celoscan.io";
             case "baklava":
-                return "https:/\/explorer.celo.org/baklava";
+                // baklava is currently not supported by celoscan.io, so we use Blockscout
+                return "https://explorer.celo.org/baklava";
             default:
         };
 

--- a/test/getHistory.ts
+++ b/test/getHistory.ts
@@ -1,0 +1,17 @@
+import { CeloscanProvider } from "../src/lib/CeloscanProvider";
+
+async function main() {
+    const account = process.env.ACCOUNT;
+    if (!account) throw new Error("No ACCOUNT provided in env");
+    const network = process.env.NETWORK?.toLocaleLowerCase() || "celo";
+    if (network !== "celo" && network !== "alfajores" && network !== "baklava") throw new Error("Invalid NETWORK provided in env. Use celo, alfajores, or baklava");
+    console.info("Using CeloscanProvider with", network.toUpperCase(), "network");
+    const provider = new CeloscanProvider();
+    const history = await provider.getHistory(account);
+    console.info("Account", account, "history:");
+    console.info(history);
+}
+
+main()
+    .then(() => console.info("Get history complete"))
+    .catch(console.error);

--- a/test/getHistory.ts
+++ b/test/getHistory.ts
@@ -6,7 +6,7 @@ async function main() {
     const network = process.env.NETWORK?.toLocaleLowerCase() || "celo";
     if (network !== "celo" && network !== "alfajores" && network !== "baklava") throw new Error("Invalid NETWORK provided in env. Use celo, alfajores, or baklava");
     console.info("Using CeloscanProvider with", network.toUpperCase(), "network");
-    const provider = new CeloscanProvider();
+    const provider = new CeloscanProvider(network);
     const history = await provider.getHistory(account);
     console.info("Account", account, "history:");
     console.info(history);

--- a/test/getHistory.ts
+++ b/test/getHistory.ts
@@ -4,7 +4,6 @@ async function main() {
     const account = process.env.ACCOUNT;
     if (!account) throw new Error("No ACCOUNT provided in env");
     const network = process.env.NETWORK?.toLocaleLowerCase() || "celo";
-    if (network !== "celo" && network !== "alfajores" && network !== "baklava") throw new Error("Invalid NETWORK provided in env. Use celo, alfajores, or baklava");
     console.info("Using CeloscanProvider with", network.toUpperCase(), "network");
     const provider = new CeloscanProvider(network);
     const history = await provider.getHistory(account);


### PR DESCRIPTION
This PR implements CeloscanProvider, a wrapper for EtherscanProvider. Thus, Celo users can access functionalities such as getHistory (obtaining transactions from a given account).

This provider uses the Celo explorer API for the 3 network options:

Celo Mainnet: https://explorer.celo.org/mainnet
Alfajores:        https://explorer.celo.org/alfajores
Baklava:         https://explorer.celo.org/baklava

- [x] Support to apiKey
- [x] Unit test
- [x] README example  
